### PR TITLE
Add `offset` parameter to API

### DIFF
--- a/views/api.py
+++ b/views/api.py
@@ -162,8 +162,10 @@ def search(request):
         if searchtype in defer:
             qs = qs.defer(*defer[searchtype])
         qs = qs.annotate(**viewutil.ModelAnnotations.get(searchtype,{}))
-        if qs.count() > 1000:
-            qs = qs[:1000]
+        offset = int(searchParams['offset'] or '0')
+        limit = 1000
+        if qs.count() > limit:
+            qs = qs[offset : (offset + limit)]
         jsonData = json.loads(serializers.serialize('json', qs, ensure_ascii=False))
         objs = dict(map(lambda o: (o.id,o), qs))
         for o in jsonData:


### PR DESCRIPTION
Adds an `offset` parameter to the public-facing API. Most notably allows developers to pre-fetch/cache all ESA runners once instead of needing to send hundreds of requests to get each individual runner (or, at least, each runner not in the list of the first 1,000).